### PR TITLE
Resolve RDFUnit dependency failure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rdfunit.version>0.7.4-SNAPSHOT</rdfunit.version>
+        <rdfunit.version>0.7.4</rdfunit.version>
         <slf4j.version>1.7.12</slf4j.version>
     </properties>
     <build>


### PR DESCRIPTION
The dependency problem is solved, but the code won't compile:

[INFO] Compiling 9 source files to /RML-RDFUnit/target/classes
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 01:05 min
[INFO] Finished at: 2016-05-09T10:31:09+00:00
[INFO] Final Memory: 38M/336M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project RML-RDFUnit: Compilation failure: Compilation failure:
[ERROR] /RML-RDFUnit/src/main/java/be/ugent/mmlab/rml/rmlvalidator/main/Main.java:[78,20] error: no suitable constructor found for FileDataset(String,String)
[ERROR] 
[ERROR] constructor FileDataset.FileDataset(String) is not applicable
[ERROR] (actual and formal argument lists differ in length)
[ERROR] constructor FileDataset.FileDataset(String,String,LocalRepositoryManager,String) is not applicable
[ERROR] (actual and formal argument lists differ in length)
[ERROR] /RML-RDFUnit/src/main/java/be/ugent/mmlab/rml/rmlvalidator/main/Main.java:[183,27] error: RMLEngine is abstract; cannot be instantiated
[ERROR] 
[ERROR] /RML-RDFUnit/src/main/java/be/ugent/mmlab/rml/rmlvalidator/main/Main.java:[191,22] error: method runRMLMapping in interface RMLEngine cannot be applied to given types;
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
The command '/bin/sh -c ./build.sh' returned a non-zero code: 1
